### PR TITLE
Corrected the missing ',' in the packages of the install_requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'pyexcel>=0.2.0',
-        'pyexcel-io>=0.1.0'
+        'pyexcel-io>=0.1.0',
         'tabulate'
     ],
     description="It is a plugin to pyexcel and provides the capbility to present and write data in text fromats",


### PR DESCRIPTION
The version in pip was throwing an exception.
```
error: pyexcel-io 0.1.0 is installed but pyexcel-io>=0.1.0tabulate is required by set(['pyexcel-text'])
```
The mistake was just corrected by appending the ','.
```
    install_requires=[
        'pyexcel>=0.2.0',
        'pyexcel-io>=0.1.0'
        'tabulate'
    ],
```